### PR TITLE
Add `--enable-watchdog` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,4 +55,7 @@ Here are the supported extra arguments:
 
 --uninstall-gui
     At the end of configuration, prompts the user to disable and uninstall the desktop environment
+
+--enable-watchdog
+    Arms the hardware watchdog and panics the kernel on hung tasks, so the machine reboots itself instead of hanging silently. Intended for headless servers.
 ```

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ Here are the supported extra arguments:
     At the end of configuration, prompts the user to disable and uninstall the desktop environment
 
 --enable-watchdog
-    Arms the hardware watchdog and panics the kernel on hung tasks, so the machine reboots itself instead of hanging silently. Intended for headless servers.
+    Arms the hardware watchdog so a machine that stops responding entirely reboots itself instead of hanging silently, and reboots a panicked or hung-shutdown kernel that would otherwise sit there forever. Intended for headless servers.
+    Deliberately minimal: it recovers only the failures that also take SSH down, and leaves a degraded-but-reachable machine alone for an operator to diagnose.
 
 --tester
     Configures the machine as a HiL (Hardware-in-the-Loop) tester or unit tester instead of a developer workstation.
@@ -78,6 +79,6 @@ This mode performs the following steps in addition to the standard setup:
 - **Creates the `hatch-runner` service account** — a system user with membership in the `dialout` and `docker` groups and passwordless sudo for `apt-get` and GitHub Actions runner service management (`systemctl start/stop/restart actions.runner.*`)
 - **Hardens SSH** — sets `PermitRootLogin no` in `/etc/ssh/sshd_config` (and a drop-in under `sshd_config.d/` on Debian 12+) and reloads the SSH daemon
 - **Saves hardware identifiers** to `/etc/hatch-tester-ids.txt` — includes hostname, machine-id, network interface MACs, and Bluetooth controller MACs
-- **Arms the hardware watchdog** (see `--enable-watchdog`) so an unattended tester reboots itself instead of hanging silently
+- **Arms the hardware watchdog** (see `--enable-watchdog`) so an unattended tester that stops responding entirely reboots itself back into SSH reach
 
 Git configuration and firmware repository cloning are skipped in tester mode.

--- a/configure.sh
+++ b/configure.sh
@@ -3,19 +3,27 @@ set -euo pipefail
 
 # Constant Config #
 
-VERSION="2.4"
+VERSION="2.5"
 HOST="https://hatch-embedded.github.io/dev-setup"
 SH="$HOME/sh"
 REBOOT_FILE="/tmp/.dev-setup-reboot-pending"
+
+WATCHDOG_DEVICE="/dev/watchdog0"
+WATCHDOG_RUNTIME_SEC=60
+WATCHDOG_REBOOT_SEC="10min"
+WATCHDOG_HUNG_TASK_SEC=300
+WATCHDOG_PANIC_SEC=30
 
 # Dynamic Config #
 
 SKIP_GIT=false
 UNINSTALL_GUI=false
+ENABLE_WATCHDOG=false
 for arg in "$@"; do
     case "$arg" in
         --uninstall-gui) UNINSTALL_GUI=true ;;
         --skip-git) SKIP_GIT=true ;;
+        --enable-watchdog) ENABLE_WATCHDOG=true ;;
     esac
 done
 
@@ -46,6 +54,24 @@ mark_reboot() {
 
 reboot_pending() {
     test -f "$REBOOT_FILE"
+}
+
+# Writes stdin to $1, creating parent directories. Returns 0 only when the
+# contents changed, so callers can skip reload side effects on repeat runs.
+write_config() {
+    local DEST="$1"
+    local TMP
+    TMP=$(mktemp)
+
+    cat > "$TMP"
+
+    if sudo cmp -s "$TMP" "$DEST"; then
+        rm -f "$TMP"
+        return 1
+    fi
+
+    sudo install -m 0644 -D "$TMP" "$DEST"
+    rm -f "$TMP"
 }
 
 user() {
@@ -175,6 +201,37 @@ install_ssh_server() {
     sudo ufw allow ssh >/dev/null
     sudo systemctl enable ssh --now >/dev/null 2>&1
     echo "✅ | INSTALL ssh server"
+}
+
+enable_watchdog() {
+    local WD_CONF="/etc/systemd/system.conf.d/watchdog.conf"
+    local SYSCTL_CONF="/etc/sysctl.d/60-hang-detect.conf"
+
+    if [ ! -e "$WATCHDOG_DEVICE" ]; then
+        echo "⚠️ $WATCHDOG_DEVICE not present"
+        return 0
+    fi
+
+    if write_config "$WD_CONF" <<EOF
+[Manager]
+RuntimeWatchdogSec=$WATCHDOG_RUNTIME_SEC
+RebootWatchdogSec=$WATCHDOG_REBOOT_SEC
+EOF
+    then
+        sudo systemctl daemon-reexec
+    fi
+
+    if write_config "$SYSCTL_CONF" <<EOF
+kernel.hung_task_panic = 1
+kernel.hung_task_timeout_secs = $WATCHDOG_HUNG_TASK_SEC
+kernel.panic_on_oops = 1
+kernel.panic = $WATCHDOG_PANIC_SEC
+EOF
+    then
+        sudo sysctl -q --system
+    fi
+
+    echo "✅ | ENABLE hardware watchdog"
 }
 
 # Check https://docs.docker.com/engine/install/ for updates
@@ -433,6 +490,11 @@ enable_sudoless_serial_port
 download_scripts
 apt_install_common
 install_ssh_server
+
+if [ "$ENABLE_WATCHDOG" = true ]; then
+    enable_watchdog
+fi
+
 install_docker
 install_claude
 schedule_updates

--- a/configure.sh
+++ b/configure.sh
@@ -345,7 +345,9 @@ kernel.panic_on_oops = 1
 kernel.panic = $WATCHDOG_PANIC_SEC
 EOF
     then
-        sudo sysctl -q --system
+        # -e: --system re-reads every distro-shipped sysctl.d file, and one
+        # unknown key anywhere would abort this script under `set -e`.
+        sudo sysctl -eq --system
     fi
 
     echo "✅ | ENABLE hardware watchdog"

--- a/configure.sh
+++ b/configure.sh
@@ -11,7 +11,6 @@ REBOOT_FILE="/tmp/.dev-setup-reboot-pending"
 WATCHDOG_DEVICE="/dev/watchdog0"
 WATCHDOG_RUNTIME_SEC=60
 WATCHDOG_REBOOT_SEC="10min"
-WATCHDOG_HUNG_TASK_SEC=300
 WATCHDOG_PANIC_SEC=30
 
 # Dynamic Config #
@@ -322,7 +321,7 @@ install_ssh_server() {
 
 enable_watchdog() {
     local WD_CONF="/etc/systemd/system.conf.d/watchdog.conf"
-    local SYSCTL_CONF="/etc/sysctl.d/60-hang-detect.conf"
+    local SYSCTL_CONF="/etc/sysctl.d/60-watchdog.conf"
 
     if [ ! -e "$WATCHDOG_DEVICE" ]; then
         echo "⚠️ $WATCHDOG_DEVICE not present"
@@ -338,10 +337,10 @@ EOF
         sudo systemctl daemon-reexec
     fi
 
+    # Only reboot a kernel that has already panicked. Panicking *proactively*
+    # (hung_task_panic, panic_on_oops) kills boxes that still accept SSH, which
+    # is the access this whole feature exists to preserve.
     if write_config "$SYSCTL_CONF" <<EOF
-kernel.hung_task_panic = 1
-kernel.hung_task_timeout_secs = $WATCHDOG_HUNG_TASK_SEC
-kernel.panic_on_oops = 1
 kernel.panic = $WATCHDOG_PANIC_SEC
 EOF
     then


### PR DESCRIPTION
After merge, people can run this command to make the test fixtures or their dev box idempotently enable watchdog timeout:

```sh
curl -fsSL https://hatch-embedded.github.io/dev-setup/configure.sh | bash -s -- --enable-watchdog
```